### PR TITLE
Establish canonical docs for project memory

### DIFF
--- a/.opencode/agents/Jelena.md
+++ b/.opencode/agents/Jelena.md
@@ -187,6 +187,7 @@ Require Klarissa to:
 - Keep instructions clear and operational
 - Surface architectural concerns instead of hiding them in execution churn
 - Keep the team aligned to the GitHub issue timeline, not scattered across chat and PRs
+- Before sequencing or escalating architecture-sensitive work, refresh durable project context from `docs/README.md`, especially `docs/architecture/invariants.md`, relevant ADRs, and `docs/project/debt.md`
 
 ## Constraints
 - Do not use old sub-task or `feature/<task-id>` workflow language

--- a/.opencode/agents/Zoran.md
+++ b/.opencode/agents/Zoran.md
@@ -102,6 +102,7 @@ The issue should be structured enough that Jelena can orchestrate it and Greg ca
 - Write issues so they are scannable and operationally useful
 - Preserve product intent while cutting ambiguity
 - Prefer concrete acceptance criteria over long narrative prose
+- Before shaping new work, refresh durable project context from `docs/README.md`, especially `docs/product/vision.md`, `docs/architecture/invariants.md`, and relevant ADRs
 
 ## Constraints
 - Do not write or edit repository code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ auth:
 - **GitHub Issue is the canonical task record.**
 - **GitHub Project is the canonical coarse-grained state tracker** using `Todo`, `In Progress`, and `Done`.
 - **Pull requests are for implementation and review only**; they are not the canonical task definition.
+- For durable project memory, start with `docs/README.md`, then use the product, architecture, ADR, and debt docs under `docs/` before relying on chat history or large mixed-purpose files.
 
 ## Ownership rules
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 Issue #14 builds the shared foundation only. The V1 leaf commands are registered and routed, but command behavior is intentionally stubbed until follow-up issues implement real GitHub operations.
 
+## Documentation
+
+Canonical product and architecture memory now lives under `docs/`.
+Start with `docs/README.md` for the documentation map and authoritative entrypoints.
+
 ## Requirements
 
 - Node.js 22+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Documentation map
+
+Start here when you need project context.
+
+This directory provides the canonical product and architecture memory for `orfe`.
+Use it to understand what the project is for, which constraints must hold, which decisions are settled, and which compromises are known.
+
+## What to read first
+
+### Product intent
+- `docs/product/vision.md`
+  - what `orfe` is for
+  - who it is for
+  - product principles
+  - v1 focus and non-goals
+
+### Architecture constraints
+- `docs/architecture/invariants.md`
+  - the architectural truths that future work must preserve
+
+### Decision history
+- `docs/architecture/adrs/`
+  - short records of accepted architecture decisions and their consequences
+
+### Known compromises
+- `docs/project/debt.md`
+  - known documentation, architecture, or process debt that should stay visible
+
+## Detailed reference material
+
+- `docs/orfe/spec.md`
+  - detailed v1 runtime, command, and behavior specification
+  - use this after the higher-level product and architecture docs when you need command semantics or deeper implementation detail
+
+## Related repository guidance
+
+- `README.md`
+  - project overview, setup, and development commands
+- `AGENTS.md`
+  - repository workflow rules, role boundaries, and GitHub operating conventions
+
+## How to use this map
+
+- Product questions: start with `docs/product/vision.md`
+- Architecture guardrails: read `docs/architecture/invariants.md`
+- "Why is it designed this way?": read the ADRs
+- "What is intentionally imperfect right now?": read `docs/project/debt.md`
+- Detailed command/runtime behavior: read `docs/orfe/spec.md`
+
+If these docs drift from implementation, prefer the source code for observed behavior and record the mismatch in `docs/project/debt.md` or a follow-up issue.

--- a/docs/architecture/adrs/0001-generic-runtime-not-workflow-engine.md
+++ b/docs/architecture/adrs/0001-generic-runtime-not-workflow-engine.md
@@ -1,0 +1,22 @@
+# ADR 0001: `orfe` is a generic runtime, not a workflow engine
+
+- Status: Accepted
+- Date: 2026-04-10
+
+## Context
+
+`orfe` exists inside a larger agent-driven development environment, but repositories already have their own workflow semantics, ownership rules, and orchestration policy.
+
+If `orfe` absorbed those repo-specific rules, it would become harder to reuse, harder to test cleanly, and more likely to confuse generic GitHub operations with repository workflow policy.
+
+## Decision
+
+Keep `orfe` as a generic GitHub operations runtime.
+
+`orfe` owns reusable GitHub operations and their contracts. Repo-specific workflow semantics remain in higher layers such as agent prompts, repository policy, and workflow orchestration tooling.
+
+## Consequences
+
+- `orfe` stays reusable across repositories with different workflow rules.
+- Product and orchestration agents can layer policy on top without forcing `orfe` to encode that policy.
+- Some behavior that feels convenient to put in `orfe` should remain outside it if it is repository-specific.

--- a/docs/architecture/adrs/0002-wrapper-core-boundary.md
+++ b/docs/architecture/adrs/0002-wrapper-core-boundary.md
@@ -1,0 +1,25 @@
+# ADR 0002: the wrapper reads runtime context and the core receives plain data
+
+- Status: Accepted
+- Date: 2026-04-10
+
+## Context
+
+`orfe` has two entrypoints: a CLI and an OpenCode tool wrapper.
+Only the OpenCode wrapper has access to runtime-specific caller context such as `context.agent`.
+
+If the core depended on that runtime context directly, it would become harder to test, less reusable, and coupled to a single execution environment.
+
+## Decision
+
+The OpenCode wrapper is the only layer allowed to read runtime-specific caller context.
+After resolving caller identity, it passes only plain structured input and `callerName` into the core.
+
+The core remains runtime-agnostic and callable from both CLI and OpenCode wrapper entrypoints.
+
+## Consequences
+
+- The core stays testable with plain requests.
+- CLI and wrapper entrypoints can share one runtime implementation.
+- OpenCode-specific concerns are isolated to the wrapper boundary.
+- Future changes that need runtime-specific data must be evaluated carefully to avoid breaking this boundary.

--- a/docs/architecture/adrs/0003-internal-github-app-auth.md
+++ b/docs/architecture/adrs/0003-internal-github-app-auth.md
@@ -1,0 +1,22 @@
+# ADR 0003: runtime auth uses internal GitHub App token minting
+
+- Status: Accepted
+- Date: 2026-04-10
+
+## Context
+
+`orfe` needs predictable role-based GitHub access for command execution.
+Relying on ambient `gh` auth, external token helpers, or silent auth fallback would make behavior less explicit and harder to reason about in agent-driven workflows.
+
+## Decision
+
+`orfe` v1 uses internal GitHub App auth.
+
+The runtime resolves `callerName` to a GitHub role, loads machine-local credentials for that role, creates the GitHub App JWT internally, resolves the target installation internally, and mints the installation token internally.
+
+## Consequences
+
+- Auth behavior stays explicit and reviewable.
+- Repo-local config remains free of secrets.
+- Machine-local auth config becomes an important operator dependency.
+- The runtime must fail clearly instead of silently switching to another auth mode.

--- a/docs/architecture/adrs/0004-octokit-over-gh-shellouts.md
+++ b/docs/architecture/adrs/0004-octokit-over-gh-shellouts.md
@@ -1,0 +1,22 @@
+# ADR 0004: command behavior uses Octokit instead of `gh` shell-outs
+
+- Status: Accepted
+- Date: 2026-04-10
+
+## Context
+
+`orfe` needs command behavior that is deterministic, testable, and independent of human-oriented shell workflows.
+Using `gh` or GitHub MCP as the implementation path would couple runtime behavior to external CLI conventions, session state, and less explicit contracts.
+
+## Decision
+
+Implement runtime command behavior with Octokit.
+
+Use REST where available and GraphQL where required for correct GitHub semantics. Do not use `gh` shell-outs or GitHub MCP as the runtime command implementation layer.
+
+## Consequences
+
+- Command behavior stays closer to explicit API contracts.
+- Tests can mock outbound HTTP calls directly with `nock`.
+- `orfe` owns more of the API integration surface itself.
+- The team must keep API usage current as GitHub behavior evolves.

--- a/docs/architecture/adrs/0005-graphql-for-project-status-and-duplicate-semantics.md
+++ b/docs/architecture/adrs/0005-graphql-for-project-status-and-duplicate-semantics.md
@@ -1,0 +1,27 @@
+# ADR 0005: use GraphQL where REST cannot express the required GitHub semantics
+
+- Status: Accepted
+- Date: 2026-04-10
+
+## Context
+
+Most issue and pull request operations fit naturally on GitHub REST APIs.
+However, some required semantics in `orfe` v1 are not captured correctly through the same REST path alone.
+
+Examples include:
+- GitHub Project Status field operations
+- issue duplicate relationships, where setting `state_reason=duplicate` is not enough to establish GitHub's canonical duplicate relationship
+
+## Decision
+
+Use GraphQL for operations where GitHub semantics require it, especially:
+- project status field read/write behavior
+- duplicate issue relationship mutations and related lookups
+
+Use REST for issue and pull request operations where REST is sufficient.
+
+## Consequences
+
+- `orfe` intentionally uses both REST and GraphQL in v1.
+- The API layer is slightly more complex, but command behavior matches GitHub's actual semantics more closely.
+- Duplicate handling can preserve GitHub's canonical relationship instead of approximating it.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -1,0 +1,45 @@
+# `orfe` architecture invariants
+
+These are the architecture constraints that future work must preserve unless a new ADR intentionally changes them.
+
+## Product boundary invariants
+
+- `orfe` is a **generic GitHub operations runtime**, not a repo-specific workflow engine.
+- Repo-specific workflow semantics belong in layers above `orfe`, such as agent prompts, skills, commands, or repository policy.
+- `orfe` should expose reusable GitHub operations, not encode one repository's orchestration model.
+
+## Runtime boundary invariants
+
+- The OpenCode wrapper is the **only** layer allowed to read OpenCode runtime caller context such as `context.agent`.
+- The core runtime accepts **plain structured data only**.
+- The core must stay callable from both CLI and OpenCode wrapper entrypoints.
+- The core must not depend on OpenCode-specific APIs or ambient agent identity.
+
+## Auth and security invariants
+
+- Repo-local config must not contain private keys or machine-local secrets.
+- Machine-local auth config contains per-role GitHub App credentials and stays outside repo-local public contract artifacts.
+- `orfe` v1 uses internal GitHub App auth for runtime command execution.
+- The runtime must not silently fall back to session auth or other ambient auth modes.
+- Caller identity, GitHub role resolution, and token minting must remain explicit steps.
+
+## Command contract invariants
+
+- Command inputs, validation rules, help behavior, and success/error envelopes are part of the public contract surface.
+- Successful commands return structured JSON.
+- Valid commands that fail at runtime return structured typed errors.
+- Changes to public command behavior should preserve contract stability or be documented intentionally.
+
+## GitHub adapter invariants
+
+- Command behavior uses Octokit directly rather than `gh` shell-outs or GitHub MCP.
+- Issue and pull request operations use REST where appropriate.
+- Project status and duplicate issue semantics use GraphQL where required for correct GitHub behavior.
+- Duplicate issue handling must establish GitHub's canonical duplicate relationship, not only set `state_reason=duplicate`.
+
+## Documentation invariants
+
+- `docs/README.md` is the entrypoint for durable product and architecture memory.
+- ADRs preserve the why behind accepted architecture decisions.
+- `docs/orfe/spec.md` is the detailed v1 behavior reference, but it is not the only place where project memory should live.
+- Generated artifacts such as `dist/` are build outputs, not canonical architecture documentation.

--- a/docs/orfe/spec.md
+++ b/docs/orfe/spec.md
@@ -3,6 +3,13 @@
 Status: canonical v1 design for issue #13  
 Applies to follow-up implementation issues #14 and #15
 
+See also:
+- `docs/README.md` for the documentation map
+- `docs/product/vision.md` for product intent and non-goals
+- `docs/architecture/invariants.md` for the architecture constraints this spec assumes
+- `docs/architecture/adrs/` for accepted design decisions captured as ADRs
+- `docs/project/debt.md` for known documentation and architecture drift
+
 ## 1. Purpose
 
 `orfe` is a stand-alone GitHub operations tool with two entrypoints:

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -1,0 +1,70 @@
+# `orfe` product vision
+
+## Summary
+
+`orfe` is a stand-alone GitHub operations runtime for humans and agents that need safe, predictable, reusable GitHub operations.
+
+It provides two entrypoints over the same core behavior:
+- an installable CLI named `orfe`
+- an OpenCode custom tool wrapper also named `orfe`
+
+## Who it is for
+
+`orfe` is for repositories and teams that already have their own workflow policy, but need a reliable GitHub operations layer underneath that policy.
+
+Primary users include:
+- agent-based development systems that need deterministic GitHub operations
+- humans operating those systems
+- repositories that need GitHub App-based role impersonation instead of ambient session auth
+
+## Problem it solves
+
+Without a dedicated runtime, GitHub operations for agents tend to become:
+- loosely defined shell usage around `gh`
+- dependent on ambient auth state
+- hard to validate consistently
+- mixed together with repo-specific workflow policy
+- brittle across wrappers, prompts, and local tooling
+
+`orfe` exists to make those operations explicit and reusable.
+
+## Product principles
+
+- **Deterministic contracts over ad hoc usage**
+  - commands should have explicit inputs, validation rules, and success/error envelopes
+- **Explicit identity and auth boundaries**
+  - caller identity and GitHub role selection must be clear and reviewable
+- **Generic GitHub operations layer**
+  - `orfe` should stay below repo-specific workflow policy rather than absorb it
+- **Safe failure over silent fallback**
+  - auth and runtime failures should be explicit instead of quietly switching behavior
+- **One core, multiple entrypoints**
+  - CLI and OpenCode wrapper usage should share the same runtime semantics
+
+## V1 focus
+
+V1 is focused on a narrow, reusable surface area:
+- issue operations
+- pull request operations
+- GitHub Project Status field operations
+- internal GitHub App auth for repo role impersonation
+- shared runtime behavior across CLI and OpenCode wrapper entrypoints
+
+## Non-goals
+
+`orfe` v1 does not aim to:
+- become a repo-specific workflow engine
+- replace task orchestration agents such as Zoran or Jelena
+- own branch/worktree workflow policy
+- rely on `gh` command behavior as the implementation path for runtime commands
+- depend on ambient session auth as the normal auth model
+- block progress on full end-to-end live GitHub validation
+
+## What success looks like
+
+`orfe` is successful when:
+- agents can call GitHub operations through a stable, documented contract
+- the same operation behaves consistently from CLI and OpenCode wrapper entrypoints
+- role-based GitHub App auth is explicit and predictable
+- repo-specific workflow layers can build on `orfe` without forcing `orfe` to absorb their policy
+- future contributors can understand the project from a small set of durable docs instead of chat history

--- a/docs/project/debt.md
+++ b/docs/project/debt.md
@@ -1,0 +1,25 @@
+# Project debt register
+
+This file keeps known documentation, architecture, and process debt visible so it does not disappear into chat history.
+
+## Current debt
+
+### 1. `docs/orfe/spec.md` is still monolithic
+- **Impact:** important knowledge is present, but product intent, architecture constraints, decisions, and command detail are still concentrated in one large document.
+- **Current treatment:** use `docs/README.md`, the new product/architecture docs, and ADRs as the fast path for project memory.
+- **Follow-up direction:** gradually split feature- and command-specific reference material out of the large spec when it becomes worthwhile.
+
+### 2. Generated artifacts can look more authoritative than they are
+- **Impact:** `dist/` may contain historical or transitional build output that does not explain the current intended architecture cleanly.
+- **Current treatment:** treat source code and docs under `docs/` as canonical; treat generated output as implementation artifacts only.
+- **Follow-up direction:** keep generated output aligned with source and reduce confusion where stale artifacts remain visible.
+
+### 3. Some operational auth guidance is still transitional
+- **Impact:** repository workflow instructions and runtime architecture can drift if operator guidance lags behind implementation changes.
+- **Current treatment:** use `docs/architecture/invariants.md` and ADRs for architecture truth, and keep operational workflow guidance in `AGENTS.md` and role prompts explicit.
+- **Follow-up direction:** continue reconciling operator guidance with the runtime as auth-related implementation evolves.
+
+### 4. Feature-level docs are still sparse
+- **Impact:** issue, PR, project, and auth flows are described mostly in the large spec rather than in smaller feature-oriented documents.
+- **Current treatment:** use the detailed spec for command semantics and the new docs for higher-level memory.
+- **Follow-up direction:** add focused feature docs when those areas become active enough to justify their own durable references.


### PR DESCRIPTION
## Summary
- add a canonical docs map, product vision, architecture invariants, ADRs, and a debt register for `orfe`
- cross-link the new docs from README, AGENTS, and the detailed spec so durable project memory is easier to discover
- point Zoran and Jelena at the new docs before they shape or sequence architecture-sensitive work

## Testing
- npm test
- npm run lint
- npm run typecheck
- npm run build