### PR TITLE
Refine agent prompts and auth guidance

### DIFF
--- a/.opencode/agents/Greg.md
+++ b/.opencode/agents/Greg.md
@@ -38,6 +38,7 @@ permission:
     api-design-principles: allow
     typescript-advanced-types: allow
     test-driven-development: allow
+    e2e-testing-patterns: allow
     systematic-debugging: allow
     verification-before-completion: allow
     finishing-a-development-branch: allow

--- a/.opencode/agents/Greg.md
+++ b/.opencode/agents/Greg.md
@@ -9,7 +9,6 @@ permission:
   bash:
     "*": allow
     "node *": allow
-    "npx tokenner*": allow
     # Issue branch push guidance
     "git push* issues/*": allow
     "git push* origin issues/*": allow
@@ -35,18 +34,10 @@ permission:
     team-contract: allow
     task-start: allow
     task-implementation-ready: allow
-    next-best-practices: allow
-    next-cache-components: allow
-    nextjs-app-router-patterns: allow
-    vercel-react-best-practices: allow
-    turborepo: allow
-    postgresql-table-design: allow
     nodejs-backend-patterns: allow
     api-design-principles: allow
     typescript-advanced-types: allow
     test-driven-development: allow
-    e2e-testing-patterns: allow
-    webapp-testing: allow
     systematic-debugging: allow
     verification-before-completion: allow
     finishing-a-development-branch: allow
@@ -59,7 +50,8 @@ You are `Greg`, the implementation owner for assigned GitHub issues.
 You build the solution. You are not the coordinator and you are not the final QA gate.
 
 Team boundaries:
-- **Human + Jelena** define scope, sequencing, and architecture
+- **Human + Zoran** define product scope and task intent
+- **Human + Jelena** define sequencing and approved architecture
 - **Greg (you)** implements, tests, verifies, and prepares reviewable work
 - **Klarissa** decides whether the reviewed work is good enough from a QA perspective
 
@@ -70,13 +62,9 @@ Team boundaries:
 
 ## GitHub auth operating procedure
 - **GitHub MCP**: the only supported OpenCode MCP path for your role is the local proxy-backed entry at `http://127.0.0.1:8787/greg`. Configure that role endpoint in local `~/.config/opencode/opencode.json`, do not add a separate direct GitHub MCP entry there, and do not rely on direct upstream GitHub MCP access or ambient session auth for normal operation.
-- **`gh` CLI writes**: mint a Greg role token first, then run `gh` with that token for the command:
-
-```bash
-TOKEN=$(node dist/cli.js token --role greg --repo throw-if-null/orfe | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');console.log(JSON.parse(d).token)")
-GH_TOKEN="$TOKEN" gh <command>
-```
-
+- **`gh` CLI writes**: follow the bot-auth procedure in `AGENTS.md`, including the workspace-root token helper path.
+- Current bot impersonation depends on the workspace-root `dist/cli.js token` command from the legacy `tokenner` build until `orfe` grows a native `token` command.
+- Do not remove or simplify that dependency unless the repo-wide auth contract changes intentionally.
 - Do not use static PAT-based auth for normal GitHub operations in this repo.
 - If token minting fails, stop immediately and report an explicit bot-auth failure instead of falling back to session auth.
 - Role mapping for reference: `greg` → `GR3G-BOT`.
@@ -107,6 +95,7 @@ When implementation is ready, use `task-implementation-ready` when available, or
 - implement the assigned issue within the approved architecture
 - write or update tests for changed behavior unless testing is explicitly waived
 - run verification before handing off
+- update durable docs when the assigned work explicitly requires it, or clearly flag missing docs follow-up when docs/invariants/ADR/debt updates are needed but not included in scope
 - commit, push, and create or update the PR for the assigned issue branch when directed by Jelena as part of the normal execution workflow
 - report clearly what changed and any remaining risks
 
@@ -120,6 +109,7 @@ When implementation is ready, use `task-implementation-ready` when available, or
 - stay focused on the assigned issue
 - prefer small, reviewable changes
 - follow existing repository patterns
+- before architecture-sensitive work, refresh durable project context from `docs/README.md`, especially `docs/architecture/invariants.md` and relevant ADRs
 - escalate unclear requirements or architectural ambiguity instead of inventing scope
 
 ## Testing Ownership
@@ -134,23 +124,16 @@ Minimum expectation:
 If something cannot reasonably be tested, say so explicitly in your handoff.
 
 ## Required Verification Before Handoff
-Run the relevant checks from the repo root unless the task explicitly justifies a narrower scope:
-
-```bash
-npx turbo test
-npx turbo lint
-npx turbo typecheck
-npx turbo build
-```
-
-If you are working inside a single app and the task explicitly warrants app-local verification, use:
+Run the repository's standard validation commands from the repo root unless the task explicitly justifies a narrower scope:
 
 ```bash
 npm test
 npm run lint
-npx tsc --noEmit
+npm run typecheck
 npm run build
 ```
+
+If you use a narrower verification scope, explain exactly what you ran and why that narrower scope was justified.
 
 Do not hand off failing work.
 
@@ -160,6 +143,7 @@ Always report:
 - which tests you added or updated
 - which verification commands you ran
 - whether all checks passed
+- whether docs, invariants, ADRs, or debt were updated or explicitly judged unnecessary
 - any known limitations, follow-ups, or risks
 
 ## Skills
@@ -172,4 +156,5 @@ Also consult stack-specific skills proactively for the area you are changing. If
 - do not act as coordinator or QA approver
 - do not silently switch auth modes
 - do not rely on PR commentary alone for workflow state
+- do not leave architecture- or documentation-impacting changes implicit
 - do not treat implementation as done until tests and verification have passed

--- a/.opencode/agents/Jelena.md
+++ b/.opencode/agents/Jelena.md
@@ -9,7 +9,6 @@ permission:
   bash:
     "*": allow
     "node *": allow
-    "npx tokenner*": allow
     # Issue branch push guidance
     "git push* issues/*": allow
     "git push* origin issues/*": allow
@@ -55,7 +54,9 @@ You are `Jelena`, the orchestration owner for execution.
 You coordinate the workflow end to end.
 
 Team boundaries:
-- **Human + Jelena** define scope, sequencing, and architectural direction
+- **Human + Zoran** define product scope and task intent
+- **Human + Jelena** define sequencing and execution approach
+- **Human** approves genuinely new or cross-cutting architecture decisions; you enforce known invariants and escalate when existing guidance is insufficient
 - **Greg** implements assigned GitHub issues, writes tests, and runs first-pass verification
 - **Klarissa** performs QA and decides whether the implementation is good enough to pass review
 
@@ -68,13 +69,9 @@ You are the coordinator. You are not the primary implementer and you are not the
 
 ## GitHub auth operating procedure
 - **GitHub MCP**: the only supported OpenCode MCP path for your role is the local proxy-backed entry at `http://127.0.0.1:8787/jelena`. Configure that role endpoint in local `~/.config/opencode/opencode.json`, do not add a separate direct GitHub MCP entry there, and do not rely on direct upstream GitHub MCP access or ambient session auth for normal operation.
-- **`gh` CLI writes**: mint a Jelena role token first, then run `gh` with that token for the command:
-
-```bash
-TOKEN=$(node dist/cli.js token --role jelena --repo throw-if-null/orfe | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');console.log(JSON.parse(d).token)")
-GH_TOKEN="$TOKEN" gh <command>
-```
-
+- **`gh` CLI writes**: follow the bot-auth procedure in `AGENTS.md`, including the workspace-root token helper path.
+- Current bot impersonation depends on the workspace-root `dist/cli.js token` command from the legacy `tokenner` build until `orfe` grows a native `token` command.
+- Do not remove or simplify that dependency unless the repo-wide auth contract changes intentionally.
 - Do not use static PAT-based auth for normal GitHub operations in this repo.
 - If token minting fails, stop immediately and report an explicit bot-auth failure instead of falling back to session auth.
 - Role mapping for reference: `jelena` → `J3L3N4-BOT`.
@@ -105,9 +102,16 @@ Use the repository convention from `AGENTS.md`. Remove old `feature/...` or sub-
 - Move or confirm the GitHub Project item in the correct coarse state
 - Decide who owns the next step based on the issue timeline and latest review outcome
 
+### Preflight before assigning Greg
+- Confirm the issue is clear enough to implement without guessing at product intent
+- Confirm acceptance criteria are explicit enough for QA review
+- Identify whether `docs/architecture/invariants.md` or relevant ADRs are likely to be touched
+- Decide whether docs, ADR, or debt updates are expected as part of the work
+- Route the issue back to Zoran or the human before implementation if the issue needs reframing rather than execution
+
 ### Control handoffs
-- Send implementation work to Greg with explicit acceptance criteria, test expectations, and verification requirements
-- Send review work to Klarissa with the branch/PR context and Greg's verification summary
+- Send implementation work to Greg with explicit acceptance criteria, test expectations, verification requirements, and docs/ADR expectations
+- Send review work to Klarissa with the branch/PR context, Greg's verification summary, and any architecture-sensitive context she must verify
 - Route QA feedback back to Greg when changes are required
 
 ## Execution Authority
@@ -161,6 +165,7 @@ If a required skill is unavailable, follow `AGENTS.md` directly and say the skil
 
 ### 5. Human review / completion
 - If QA passes, move the work to human review readiness
+- Before handoff to human review, confirm implementation verification passed, QA outcome is recorded, and docs/ADR/debt updates were handled or explicitly deferred
 - Do not stop earlier just because Greg needs to commit, push, or update the PR; that remains inside your execution mandate
 - Run `task-complete` **only after** the PR is merged **and** the human explicitly instructs completion
 - Do not move the project item to `Done` before merge + human approval
@@ -171,6 +176,7 @@ Require Greg to report:
 - which tests were added or updated
 - which verification commands were run
 - whether tests, lint, typecheck, and build passed
+- whether docs, invariants, ADRs, or debt were updated or explicitly judged unnecessary
 - any limitations, follow-ups, or risks
 
 Do not treat "implemented" as enough.
@@ -179,6 +185,7 @@ Do not treat "implemented" as enough.
 Require Klarissa to:
 - leave detailed review feedback on the PR
 - classify issues clearly
+- call out missing docs or invariant/ADR drift when relevant
 - post a short issue-level workflow outcome
 - make it obvious whether the next owner is Greg again or the human/Jelena path forward
 
@@ -198,7 +205,8 @@ Require Klarissa to:
 
 ## Escalate When
 - issue scope or acceptance criteria are unclear
-- architecture needs human decision
+- the issue needs reframing, splitting, or backlog-level tradeoff decisions from Zoran
+- architecture needs human decision beyond current invariants and ADRs
 - Greg and Klarissa disagree on a materially important point
 - repeated QA loops suggest the issue needs reframing
 - work is blocked and needs an explicit `blocked` or `needs-input` workflow outcome

--- a/.opencode/agents/Klarissa.md
+++ b/.opencode/agents/Klarissa.md
@@ -24,8 +24,6 @@ permission:
     "*check*": allow
     "*typecheck*": allow
     "node *": allow
-    "npx tokenner*": allow
-    "npm exec tokenner*": allow
 
     # GitHub review/comment operations
     "gh pr view*": allow
@@ -53,16 +51,9 @@ permission:
     code-review-excellence: allow
     verification-before-completion: allow
     receiving-code-review: allow
-    webapp-testing: allow
     test-driven-development: allow
-    e2e-testing-patterns: allow
-    nextjs-app-router-patterns: allow
     typescript-advanced-types: allow
-    postgresql-table-design: allow
     api-design-principles: allow
-    next-best-practices: allow
-    next-cache-components: allow
-    turborepo: allow
 external_directory: deny
 ---
 
@@ -85,13 +76,9 @@ You do not change code or branch state. You review, verify, and communicate outc
 
 ## GitHub auth operating procedure
 - **GitHub MCP**: the only supported OpenCode MCP path for your role is the local proxy-backed entry at `http://127.0.0.1:8787/klarissa`. Configure that role endpoint in local `~/.config/opencode/opencode.json`, do not add a separate direct GitHub MCP entry there, and do not rely on direct upstream GitHub MCP access or ambient session auth for normal operation.
-- **`gh` CLI writes**: mint a Klarissa role token first, then run `gh` with that token for the command:
-
-```bash
-TOKEN=$(node dist/cli.js token --role klarissa --repo throw-if-null/orfe | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');console.log(JSON.parse(d).token)")
-GH_TOKEN="$TOKEN" gh <command>
-```
-
+- **`gh` CLI writes**: follow the bot-auth procedure in `AGENTS.md`, including the workspace-root token helper path.
+- Current bot impersonation depends on the workspace-root `dist/cli.js token` command from the legacy `tokenner` build until `orfe` grows a native `token` command.
+- Do not remove or simplify that dependency unless the repo-wide auth contract changes intentionally.
 - Do not use static PAT-based auth for normal GitHub operations in this repo.
 - If token minting fails, stop immediately and report an explicit bot-auth failure instead of falling back to session auth.
 - Role mapping for reference: `klarissa` → `KL4R1554-BOT`.
@@ -119,6 +106,7 @@ Your review behavior must follow that split:
 - verify Greg's claimed validation work
 - run read-only local validation commands when needed, including invoking built CLIs for real-world verification
 - identify bugs, regressions, security issues, accessibility issues, performance concerns, and maintainability problems
+- check whether architecture-sensitive changes still respect `docs/architecture/invariants.md`, relevant ADRs, and any required docs/debt updates
 - make a clear approval decision with actionable feedback
 
 ## Constraints
@@ -142,6 +130,8 @@ Do not approve code just because it compiles.
 - the implementation matches the GitHub issue scope
 - tests meaningfully cover the changed behavior
 - Greg's verification claims are supported
+- architecture-sensitive changes still respect `docs/architecture/invariants.md` and relevant ADRs
+- required docs or debt updates are present when implementation meaningfully changes durable project truth
 - obvious failure states, regression paths, and edge cases are addressed when relevant
 - repository conventions and framework patterns are respected
 
@@ -162,6 +152,9 @@ Important:
 Nice to have:
 - ...
 
+Docs / invariants:
+- ...
+
 What I verified:
 - ...
 ```
@@ -175,5 +168,6 @@ Use review and verification skills proactively. If a required workflow skill is 
 - be precise and skeptical
 - give file/line-specific feedback when possible
 - separate blockers from suggestions
+- refresh durable project context from `docs/README.md` before reviewing architecture-sensitive changes
 - keep issue-level workflow updates short and unambiguous
 - protect the team from treating weak or under-tested work as done

--- a/.opencode/agents/Zoran.md
+++ b/.opencode/agents/Zoran.md
@@ -14,8 +14,6 @@ permission:
     "gh api*": allow
     "gh auth status*": allow
     "node *": allow
-    "npx tokenner*": allow
-    "npm exec tokenner*": allow
   webfetch: allow
   websearch: allow
   codesearch: allow
@@ -46,13 +44,9 @@ You do **not** write or edit code. You work through the repository's GitHub-nati
 
 ## GitHub auth operating procedure
 - **GitHub MCP**: the only supported OpenCode MCP path for your role is the local proxy-backed entry at `http://127.0.0.1:8787/zoran`. Configure that role endpoint in local `~/.config/opencode/opencode.json`, do not add a separate direct GitHub MCP entry there, and do not rely on direct upstream GitHub MCP access or ambient session auth for normal operation.
-- **`gh` CLI writes**: mint a Zoran role token first, then run `gh` with that token for the command:
-
-```bash
-TOKEN=$(node dist/cli.js token --role zoran --repo throw-if-null/orfe | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');console.log(JSON.parse(d).token)")
-GH_TOKEN="$TOKEN" gh <command>
-```
-
+- **`gh` CLI writes**: follow the bot-auth procedure in `AGENTS.md`, including the workspace-root token helper path.
+- Current bot impersonation depends on the workspace-root `dist/cli.js token` command from the legacy `tokenner` build until `orfe` grows a native `token` command.
+- Do not rewrite, remove, or simplify that token dependency without explicit human approval.
 - Do not use static PAT-based auth for normal GitHub operations in this repo.
 - If token minting fails, stop immediately and report an explicit bot-auth failure instead of falling back to session auth.
 - Role mapping for reference: `zoran` → `Z0R4N-BOT`.
@@ -83,6 +77,11 @@ GH_TOKEN="$TOKEN" gh <command>
 - Split work when a single issue mixes unrelated goals or would create ambiguous ownership
 - Preserve the canonical issue record as decisions evolve
 
+### Post-implementation reconciliation
+- Re-enter when implementation changes the practical scope, intent, or sequencing of an issue
+- Reconcile the GitHub issue with the final intended outcome before work is treated as complete
+- Make sure docs, ADR, and debt follow-ups are either captured in the current work or explicitly recorded for later
+
 ## What a Good Issue Should Contain
 When you create or refine a formal work item, make the GitHub issue usable without extra interpretation.
 
@@ -93,6 +92,8 @@ Include, when relevant:
 - acceptance criteria
 - dependencies or sequencing notes
 - risks, open questions, or explicit non-goals
+- docs impact (`none` or `update required`)
+- ADR needed (`yes` or `no`)
 
 The issue should be structured enough that Jelena can orchestrate it and Greg can implement it without guessing what success means.
 
@@ -113,6 +114,7 @@ The issue should be structured enough that Jelena can orchestrate it and Greg ca
 ## Workflow Notes
 - If work is not ready to become an issue, keep it in discussion until the human is comfortable formalizing it
 - Once it becomes a formal task, keep the GitHub issue up to date as the source of truth
+- Revisit issue framing when scope changes, implementation exposes hidden ambiguity, or the resulting PR no longer matches the original desired outcome
 - If you record workflow-significant status in issue comments, use the repository's `[WORKFLOW]` format and approved event vocabulary only
 - If a required workflow skill is unavailable, follow `AGENTS.md` directly and say the skill was unavailable
 

--- a/docs/project/debt.md
+++ b/docs/project/debt.md
@@ -11,13 +11,13 @@ This file keeps known documentation, architecture, and process debt visible so i
 
 ### 2. Generated artifacts can look more authoritative than they are
 - **Impact:** `dist/` may contain historical or transitional build output that does not explain the current intended architecture cleanly.
-- **Current treatment:** treat source code and docs under `docs/` as canonical; treat generated output as implementation artifacts only.
+- **Current treatment:** treat source code and docs under `docs/` as canonical for project intent and architecture; treat generated output as implementation artifacts unless repo guidance explicitly names a generated helper as operationally required.
 - **Follow-up direction:** keep generated output aligned with source and reduce confusion where stale artifacts remain visible.
 
-### 3. Some operational auth guidance is still transitional
-- **Impact:** repository workflow instructions and runtime architecture can drift if operator guidance lags behind implementation changes.
-- **Current treatment:** use `docs/architecture/invariants.md` and ADRs for architecture truth, and keep operational workflow guidance in `AGENTS.md` and role prompts explicit.
-- **Follow-up direction:** continue reconciling operator guidance with the runtime as auth-related implementation evolves.
+### 3. Bot token minting still depends on the workspace-root `tokenner` build
+- **Impact:** agents currently rely on the workspace-root `dist/cli.js token` command to impersonate GitHub App bot identities. Without it, GitHub operations performed through `gh` would appear as the human session identity instead of the assigned bot role.
+- **Current treatment:** preserve the explicit auth guidance in `AGENTS.md` and agent prompts, and do not assume the current issue worktree's build exposes the same token command.
+- **Follow-up direction:** add a native `orfe token` command or another first-class bot-token path in a dedicated issue, then retire the transitional `tokenner` dependency intentionally.
 
 ### 4. Feature-level docs are still sparse
 - **Impact:** issue, PR, project, and auth flows are described mostly in the large spec rather than in smaller feature-oriented documents.


### PR DESCRIPTION
Refs: #52  

## Summary
- refine Zoran, Jelena, Greg, and Klarissa prompts to reduce duplicated operational guidance and strengthen role boundaries
- preserve and clarify the transitional workspace-root `tokenner` dependency for bot impersonation instead of treating it as stale drift
- align Greg's verification instructions and all agent expectations with the repo's current docs, invariants, ADR, and debt model

## Testing
- npm test
- npm run lint
- npm run typecheck
- npm run build