### PR TITLE
Operationalize docs and workflow structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -28,18 +28,13 @@ assignees: ''
 
 ## Docs impact
 
-- [ ] none
-- [ ] update existing docs
-- [ ] add new durable docs
-
-Details:
+- Docs impact: none | update existing docs | add new durable docs
+- Details:
 
 ## ADR needed?
 
-- [ ] no
-- [ ] yes
-
-Details:
+- ADR needed: no | yes
+- Details:
 
 ## Dependencies / sequencing notes
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,50 @@
+---
+name: Formal work item
+about: Create a scoped work item for product, architecture, implementation, or documentation changes
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Problem / context
+
+<!-- What problem are we solving? Why does it matter now? -->
+
+## Desired outcome
+
+<!-- What should be true after this work is done? -->
+
+## Scope
+
+### In scope
+- 
+
+### Out of scope
+- 
+
+## Acceptance criteria
+
+- [ ] 
+
+## Docs impact
+
+- [ ] none
+- [ ] update existing docs
+- [ ] add new durable docs
+
+Details:
+
+## ADR needed?
+
+- [ ] no
+- [ ] yes
+
+Details:
+
+## Dependencies / sequencing notes
+
+- 
+
+## Risks / open questions / non-goals
+
+- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+Ref: #<issue-number>
+
+## Summary
+- ...
+
+## Verification
+- [ ] npm test
+- [ ] npm run lint
+- [ ] npm run typecheck
+- [ ] npm run build
+
+## Docs / ADR / debt
+- [ ] no durable-doc change needed
+- [ ] docs updated
+- [ ] ADR updated
+- [ ] debt updated
+
+Details:
+- ...
+
+## Risks / follow-ups
+- ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,10 @@ Ref: #<issue-number>
 ## Summary
 - ...
 
+## Workflow link
+- [ ] first line is `Ref: #<issue-number>`
+- [ ] does not use `Closes`, `Fixes`, or other auto-closing keywords
+
 ## Verification
 - [ ] npm test
 - [ ] npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,9 +137,11 @@ Do not invent new workflow states if an existing event fits.
 
 - Open a PR only for implementation/review work tied to a GitHub issue.
 - Keep PR scope aligned to the single issue branch.
-- Reference the canonical issue in the PR.
+- Every implementation PR must reference the canonical GitHub issue in the **first line** of the PR body using `Ref: #<issue-number>`.
+- Do **not** use `Closes`, `Fixes`, or similar auto-closing keywords by default; merge must not silently bypass the repository's explicit completion workflow.
 - Ensure implementation, tests, and verification are complete before requesting review.
 - Do not treat PR open/close state as the task source of truth.
+- A PR that does not reference the canonical issue correctly is not review-ready.
 
 ## Standard workflow
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Issue #14 builds the shared foundation only. The V1 leaf commands are registered
 
 Canonical product and architecture memory now lives under `docs/`.
 Start with `docs/README.md` for the documentation map and authoritative entrypoints.
+For operational workflow structure, also see `.github/ISSUE_TEMPLATE/feature.md` and `docs/project/handoffs.md`.
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,10 @@ Use it to understand what the project is for, which constraints must hold, which
 ### Architecture constraints
 - `docs/architecture/invariants.md`
   - the architectural truths that future work must preserve
+- `docs/architecture/overview.md`
+  - the major runtime parts and how they fit together
+- `docs/architecture/auth-model.md`
+  - the current runtime auth model and transitional bot token path
 
 ### Decision history
 - `docs/architecture/adrs/`
@@ -25,6 +29,8 @@ Use it to understand what the project is for, which constraints must hold, which
 ### Known compromises
 - `docs/project/debt.md`
   - known documentation, architecture, or process debt that should stay visible
+- `docs/project/handoffs.md`
+  - standard templates for agent-to-agent workflow handoffs
 
 ## Detailed reference material
 
@@ -43,8 +49,11 @@ Use it to understand what the project is for, which constraints must hold, which
 
 - Product questions: start with `docs/product/vision.md`
 - Architecture guardrails: read `docs/architecture/invariants.md`
+- System shape: read `docs/architecture/overview.md`
+- Auth and bot identity model: read `docs/architecture/auth-model.md`
 - "Why is it designed this way?": read the ADRs
 - "What is intentionally imperfect right now?": read `docs/project/debt.md`
+- "How should agents hand work to each other?": read `docs/project/handoffs.md`
 - Detailed command/runtime behavior: read `docs/orfe/spec.md`
 
 If these docs drift from implementation, prefer the source code for observed behavior and record the mismatch in `docs/project/debt.md` or a follow-up issue.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,11 @@ Use it to understand what the project is for, which constraints must hold, which
 ### Known compromises
 - `docs/project/debt.md`
   - known documentation, architecture, or process debt that should stay visible
+
+## Workflow guidance
+
 - `docs/project/handoffs.md`
-  - standard templates for agent-to-agent workflow handoffs
+  - standard templates for agent-to-agent handoffs and their matching workflow events
 
 ## Detailed reference material
 

--- a/docs/architecture/auth-model.md
+++ b/docs/architecture/auth-model.md
@@ -1,0 +1,81 @@
+# `orfe` auth model
+
+## Summary
+
+`orfe` separates GitHub command behavior from GitHub identity handling.
+
+For runtime command behavior, `orfe` uses internal GitHub App auth.
+For agent-driven `gh` CLI operations outside runtime commands, the repository still depends on the workspace-root `tokenner` build to mint bot tokens.
+
+This document explains both paths and why they currently coexist.
+
+## Why bot impersonation matters
+
+The repo relies on role-specific bot identities:
+- `Z0R4N-BOT`
+- `J3L3N4-BOT`
+- `GR3G-BOT`
+- `KL4R1554-BOT`
+
+Without bot impersonation, `gh` operations would appear as the human operator's session identity instead of the assigned role.
+That would weaken auditability, confuse workflow ownership, and blur the distinction between human and agent actions.
+
+## Runtime auth inside `orfe`
+
+For `orfe` command execution:
+1. caller identity is resolved
+2. repo-local config maps caller name to GitHub role
+3. machine-local auth config provides per-role GitHub App credentials
+4. `orfe` mints the GitHub App JWT internally
+5. `orfe` resolves the installation internally
+6. `orfe` mints the installation token internally
+7. the runtime uses that token to build Octokit clients
+
+This is the intended v1 runtime auth model.
+
+## Transitional `tokenner` dependency
+
+The repository evolved from a smaller CLI named `tokenner` into the broader `orfe` runtime.
+
+Agents still use the workspace-root helper:
+
+```bash
+node /home/backsippan/gh/tin/orfe/dist/cli.js token --role <role> --repo throw-if-null/orfe --format json
+```
+
+That command remains necessary for bot-authenticated `gh` CLI operations performed by agents.
+
+## Why the workspace-root helper matters
+
+Do not assume the current issue worktree's `dist/cli.js` exposes the same token command.
+The supported helper is the workspace-root build named in `AGENTS.md`.
+
+This prevents worktree-local build drift from breaking bot-authenticated GitHub operations.
+
+## Current two-path model
+
+### Path A: runtime command execution
+- used by `orfe` command behavior
+- auth is internal to the runtime
+- no external token provider shell-out for runtime command behavior
+
+### Path B: agent `gh` CLI operations
+- used for GitHub issue, PR, project, and review actions outside direct runtime command execution
+- bot token is minted first via the workspace-root `tokenner` build
+- `gh` is then run with `GH_TOKEN`
+
+## Future direction
+
+The long-term simplification path is to provide a native `orfe token` command or another first-class bot-token path, then retire the transitional `tokenner` dependency intentionally.
+
+Until that happens:
+- preserve the current helper path explicitly
+- do not treat it as accidental legacy drift
+- do not remove or simplify it without a planned migration
+
+## Related docs
+
+- `AGENTS.md`
+- `docs/architecture/invariants.md`
+- `docs/project/debt.md`
+- `docs/orfe/spec.md`

--- a/docs/architecture/auth-model.md
+++ b/docs/architecture/auth-model.md
@@ -37,13 +37,9 @@ This is the intended v1 runtime auth model.
 
 The repository evolved from a smaller CLI named `tokenner` into the broader `orfe` runtime.
 
-Agents still use the workspace-root helper:
+Agents still use the workspace-root helper defined in `AGENTS.md`.
 
-```bash
-node /home/backsippan/gh/tin/orfe/dist/cli.js token --role <role> --repo throw-if-null/orfe --format json
-```
-
-That command remains necessary for bot-authenticated `gh` CLI operations performed by agents.
+That helper remains necessary for bot-authenticated `gh` CLI operations performed by agents.
 
 ## Why the workspace-root helper matters
 
@@ -54,14 +50,18 @@ This prevents worktree-local build drift from breaking bot-authenticated GitHub 
 
 ## Current two-path model
 
+These two paths are not peer product features.
+Path A is part of the `orfe` runtime architecture.
+Path B is repository operating procedure used by agents when they perform `gh` CLI operations outside direct runtime command execution.
+
 ### Path A: runtime command execution
 - used by `orfe` command behavior
 - auth is internal to the runtime
 - no external token provider shell-out for runtime command behavior
 
-### Path B: agent `gh` CLI operations
+### Path B: agent `gh` CLI operations (repository operating procedure)
 - used for GitHub issue, PR, project, and review actions outside direct runtime command execution
-- bot token is minted first via the workspace-root `tokenner` build
+- bot token is minted first via the workspace-root helper referenced in `AGENTS.md`
 - `gh` is then run with `GH_TOKEN`
 
 ## Future direction

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -11,7 +11,7 @@ The design goal is to provide deterministic, reusable GitHub operations without 
 ## Major runtime parts
 
 ### 1. OpenCode wrapper
-Located at `.opencode/tools/orfe.ts`.
+Currently represented by `.opencode/tools/orfe.ts` and related wrapper code.
 
 Responsibilities:
 - expose the custom tool name
@@ -24,7 +24,7 @@ It must not:
 - pass raw OpenCode runtime objects into the core
 
 ### 2. CLI entrypoint
-Located under `src/cli.ts` and related CLI code.
+Currently represented by `src/cli.ts` and related CLI code.
 
 Responsibilities:
 - parse CLI arguments
@@ -33,7 +33,7 @@ Responsibilities:
 - print structured JSON success or structured errors
 
 ### 3. Core runtime
-Located under `src/core.ts` and related command/config/runtime code.
+Currently represented by `src/core.ts` and related command/config/runtime code.
 
 Responsibilities:
 - validate command input
@@ -47,7 +47,7 @@ Responsibilities:
 The core is runtime-agnostic and must remain callable from both CLI and wrapper entrypoints.
 
 ### 4. Config layer
-Main files include `src/config.ts` and `.orfe/config.json`.
+Current examples include `src/config.ts` and `.orfe/config.json`.
 
 Responsibilities:
 - hold repo-local non-secret configuration
@@ -55,7 +55,7 @@ Responsibilities:
 - define repository and project defaults
 
 ### 5. Auth layer
-Main file includes `src/github.ts` and machine-local auth config.
+Current examples include `src/github.ts` and machine-local auth config.
 
 Responsibilities:
 - load machine-local per-role GitHub App credentials
@@ -63,7 +63,7 @@ Responsibilities:
 - keep secret-bearing auth details outside repo-local config
 
 ### 6. GitHub adapter layer
-Main files include command handlers and client factories.
+Current examples include command handlers and client factories.
 
 Responsibilities:
 - use Octokit REST where appropriate for issue and PR behavior
@@ -93,6 +93,9 @@ OpenCode wrapper / CLI
 - machine-local auth config contains role credentials
 - command behavior uses Octokit, not `gh` shell-outs
 - repo workflow policy belongs above `orfe`, not inside it
+
+These file references are descriptive of the current layout, not a promise that file organization will never change.
+When files move, update this overview if the conceptual boundaries also need clarification.
 
 ## Related docs
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,102 @@
+# `orfe` architecture overview
+
+## Summary
+
+`orfe` is a stand-alone GitHub operations runtime with two entrypoints over the same core behavior:
+- a CLI named `orfe`
+- an OpenCode custom tool wrapper named `orfe`
+
+The design goal is to provide deterministic, reusable GitHub operations without embedding repository-specific workflow policy into the runtime itself.
+
+## Major runtime parts
+
+### 1. OpenCode wrapper
+Located at `.opencode/tools/orfe.ts`.
+
+Responsibilities:
+- expose the custom tool name
+- read `context.agent`
+- resolve a plain `callerName`
+- pass only plain data into the runtime core
+
+It must not:
+- call GitHub directly for command behavior
+- pass raw OpenCode runtime objects into the core
+
+### 2. CLI entrypoint
+Located under `src/cli.ts` and related CLI code.
+
+Responsibilities:
+- parse CLI arguments
+- resolve caller identity for direct CLI usage
+- invoke the same runtime core used by the wrapper
+- print structured JSON success or structured errors
+
+### 3. Core runtime
+Located under `src/core.ts` and related command/config/runtime code.
+
+Responsibilities:
+- validate command input
+- load repo-local config
+- resolve caller-to-role mapping
+- load machine-local auth config
+- build GitHub clients
+- dispatch command handlers
+- return structured success or typed errors
+
+The core is runtime-agnostic and must remain callable from both CLI and wrapper entrypoints.
+
+### 4. Config layer
+Main files include `src/config.ts` and `.orfe/config.json`.
+
+Responsibilities:
+- hold repo-local non-secret configuration
+- map caller names to GitHub roles
+- define repository and project defaults
+
+### 5. Auth layer
+Main file includes `src/github.ts` and machine-local auth config.
+
+Responsibilities:
+- load machine-local per-role GitHub App credentials
+- mint installation tokens
+- keep secret-bearing auth details outside repo-local config
+
+### 6. GitHub adapter layer
+Main files include command handlers and client factories.
+
+Responsibilities:
+- use Octokit REST where appropriate for issue and PR behavior
+- use GraphQL where required for project status and duplicate semantics
+- preserve deterministic command behavior and structured outputs
+
+## Module map
+
+```text
+OpenCode wrapper / CLI
+        |
+        v
+   core runtime
+        |
+        +--> config loading
+        +--> caller -> role resolution
+        +--> auth/token minting
+        +--> GitHub client factory
+        +--> command registry / handlers
+```
+
+## Architectural rules to keep in mind
+
+- wrapper reads OpenCode context; core does not
+- core accepts plain data only
+- repo-local config contains no secrets
+- machine-local auth config contains role credentials
+- command behavior uses Octokit, not `gh` shell-outs
+- repo workflow policy belongs above `orfe`, not inside it
+
+## Related docs
+
+- `docs/architecture/invariants.md`
+- `docs/architecture/auth-model.md`
+- `docs/architecture/adrs/`
+- `docs/orfe/spec.md`

--- a/docs/project/debt.md
+++ b/docs/project/debt.md
@@ -21,5 +21,10 @@ This file keeps known documentation, architecture, and process debt visible so i
 
 ### 4. Feature-level docs are still sparse
 - **Impact:** issue, PR, project, and auth flows are described mostly in the large spec rather than in smaller feature-oriented documents.
-- **Current treatment:** use the detailed spec for command semantics and the new docs for higher-level memory.
+- **Current treatment:** use the detailed spec for command semantics, the architecture overview/auth model docs for system context, and the new docs for higher-level memory.
 - **Follow-up direction:** add focused feature docs when those areas become active enough to justify their own durable references.
+
+### 5. Workflow structure now has templates, but enforcement is still lightweight
+- **Impact:** issue and handoff quality should improve, but the repo still depends on humans and agents consistently using the templates rather than enforcing them mechanically.
+- **Current treatment:** provide a standard issue template and documented handoff formats as the default path.
+- **Follow-up direction:** consider GitHub issue forms, additional automation, or skill-level enforcement if drift remains high.

--- a/docs/project/handoffs.md
+++ b/docs/project/handoffs.md
@@ -70,6 +70,7 @@ Use when implementation work is being assigned.
 ## Greg → Klarissa
 
 Use when implementation is ready for QA review.
+Before opening or updating the PR, make sure the PR body starts with `Ref: #<issue-number>` so the canonical issue remains linked.
 
 ```md
 ## Implementation-ready handoff

--- a/docs/project/handoffs.md
+++ b/docs/project/handoffs.md
@@ -1,0 +1,131 @@
+# Workflow handoff templates
+
+Use these templates to keep agent-to-agent handoffs structured and easy to scan.
+These are operational defaults for normal work in `orfe`.
+
+## Zoran → Jelena
+
+Use when a discussion becomes a formal work item or when a formal work item is materially reshaped.
+
+```md
+## Handoff
+- Issue: #<number>
+- Title: <issue title>
+
+### Problem / context
+- ...
+
+### Desired outcome
+- ...
+
+### Scope boundaries
+- In scope: ...
+- Out of scope: ...
+
+### Acceptance criteria
+- ...
+
+### Risks / open questions
+- ...
+
+### Docs impact
+- none | update required
+- details: ...
+
+### ADR needed
+- no | yes
+- details: ...
+```
+
+## Jelena → Greg
+
+Use when implementation work is being assigned.
+
+```md
+## Assignment
+- Issue: #<number>
+- Branch/worktree: `issues/<acronym>-<number>` / `.worktrees/<acronym>-<number>`
+
+### What to build
+- ...
+
+### Acceptance criteria
+- ...
+
+### Constraints / invariants to preserve
+- ...
+
+### Verification required
+- `npm test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run build`
+
+### Docs / ADR expectations
+- docs expected: yes | no
+- ADR expected: yes | no
+- debt update expected: yes | no
+```
+
+## Greg → Klarissa
+
+Use when implementation is ready for QA review.
+
+```md
+## Implementation-ready handoff
+- Issue: #<number>
+- PR: #<number>
+
+### What changed
+- ...
+
+### Tests added or updated
+- ...
+
+### Verification run
+- `npm test` ✅/❌
+- `npm run lint` ✅/❌
+- `npm run typecheck` ✅/❌
+- `npm run build` ✅/❌
+
+### Docs / ADR / debt
+- docs updated: yes | no
+- ADR updated: yes | no
+- debt updated: yes | no
+- if no, explain why: ...
+
+### Known limitations / follow-ups / risks
+- ...
+```
+
+## Klarissa → Jelena
+
+Use after QA review is complete.
+
+```md
+## QA outcome
+- Issue: #<number>
+- PR: #<number>
+- Decision: APPROVED | CHANGES REQUIRED
+
+### Blockers
+- ...
+
+### Important
+- ...
+
+### Docs / invariants review
+- ...
+
+### What I verified
+- ...
+
+### Next owner
+- Greg | Jelena | Human
+```
+
+## Notes
+
+- Keep the GitHub issue as the workflow source of truth.
+- Keep detailed code review comments in the PR.
+- Keep issue-level workflow outcomes aligned to the approved `[WORKFLOW]` event vocabulary in `AGENTS.md`.

--- a/docs/project/handoffs.md
+++ b/docs/project/handoffs.md
@@ -3,9 +3,20 @@
 Use these templates to keep agent-to-agent handoffs structured and easy to scan.
 These are operational defaults for normal work in `orfe`.
 
+## Handoff messages vs `[WORKFLOW]` issue events
+
+These are different artifacts and both matter:
+
+- **handoff messages** explain work, expectations, review context, and risks
+- **`[WORKFLOW]` issue events** are the official workflow record in the GitHub issue timeline
+
+A handoff message does **not** replace the required `[WORKFLOW]` issue event.
+Use the handoff template for communication, and post the matching issue-level workflow event for the official record.
+
 ## Zoran → Jelena
 
 Use when a discussion becomes a formal work item or when a formal work item is materially reshaped.
+Issue creation/refinement does not by itself imply a new `[WORKFLOW]` event; use normal workflow events only when execution state actually changes.
 
 ```md
 ## Handoff
@@ -40,6 +51,7 @@ Use when a discussion becomes a formal work item or when a formal work item is m
 ## Jelena → Greg
 
 Use when implementation work is being assigned.
+Matching issue event: post `[WORKFLOW] Event: start` when implementation ownership begins and the issue moves into active execution.
 
 ```md
 ## Assignment
@@ -71,6 +83,7 @@ Use when implementation work is being assigned.
 
 Use when implementation is ready for QA review.
 Before opening or updating the PR, make sure the PR body starts with `Ref: #<issue-number>` so the canonical issue remains linked.
+Matching issue event: post `[WORKFLOW] Event: implementation-ready` when Greg hands off completed implementation for QA.
 
 ```md
 ## Implementation-ready handoff
@@ -102,6 +115,7 @@ Before opening or updating the PR, make sure the PR body starts with `Ref: #<iss
 ## Klarissa → Jelena
 
 Use after QA review is complete.
+Matching issue event: post `[WORKFLOW] Event: qa-passed` or `[WORKFLOW] Event: qa-changes-requested` to record the official QA outcome.
 
 ```md
 ## QA outcome
@@ -130,3 +144,11 @@ Use after QA review is complete.
 - Keep the GitHub issue as the workflow source of truth.
 - Keep detailed code review comments in the PR.
 - Keep issue-level workflow outcomes aligned to the approved `[WORKFLOW]` event vocabulary in `AGENTS.md`.
+- Example issue comment for implementation handoff:
+
+```text
+[WORKFLOW]
+Event: implementation-ready
+Owner: Greg
+Notes: Implementation complete, PR updated, ready for QA.
+```


### PR DESCRIPTION
Ref: #54 

## Summary
- add an issue template plus explicit handoff templates so phase-one project memory becomes part of the day-to-day workflow
- document the runtime architecture and current auth model, including the transitional workspace-root `tokenner` dependency for bot-authenticated `gh` operations
- wire the new operational docs into the existing docs map, README, and debt register

## Testing
- npm test
- npm run lint
- npm run typecheck
- npm run build